### PR TITLE
Fix plugin rules for multiple prefixed declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const extractDuplicatedProps = (rule) => {
 module.exports = postcss.plugin('autoprefixer-tv', () =>
     (css) => {
         css.walkRules((rule) => {
+            const removeDeclarations = [];
             let duplicatedProps = extractDuplicatedProps(rule);
             duplicatedProps = filterOnlyPrefixedProps(rule, duplicatedProps);
 
@@ -43,10 +44,12 @@ module.exports = postcss.plugin('autoprefixer-tv', () =>
                         postcss.decl({ prop: decl.prop, value: decl.value })
                     );
 
-                    rule.removeChild(decl);
+                    removeDeclarations.push(decl);
                     rule.parent.insertBefore(rule, newRule);
                 }
             });
+
+            removeDeclarations.forEach(r => rule.removeChild(r));
         });
     }
 );

--- a/tests/expects/multiple-prefixed-properties.css
+++ b/tests/expects/multiple-prefixed-properties.css
@@ -1,0 +1,24 @@
+.example-with-three{
+    font-size:-webkit-calc(10vw + 10px);
+}
+.example-with-three{
+    line-height:-webkit-calc(20vw + 20px);
+}
+.example-with-three{
+    max-height:-webkit-calc(30vw + 30px);
+}
+.example-with-three{
+    font-size:calc(10vw + 10px);
+    line-height:calc(20vw + 20px);
+    max-height:calc(30vw + 30px);
+}
+.example-with-two{
+    font-size:-webkit-calc(10vw + 10px);
+}
+.example-with-two{
+    line-height:-webkit-calc(20vw + 20px);
+}
+.example-with-two{
+    font-size:calc(10vw + 10px);
+    line-height:calc(20vw + 20px);
+}

--- a/tests/fixtures/multiple-prefixed-properties.css
+++ b/tests/fixtures/multiple-prefixed-properties.css
@@ -1,0 +1,14 @@
+.example-with-three{
+    font-size:-webkit-calc(10vw + 10px);
+    font-size:calc(10vw + 10px);
+    line-height:-webkit-calc(20vw + 20px);
+    line-height:calc(20vw + 20px);
+    max-height:-webkit-calc(30vw + 30px);
+    max-height:calc(30vw + 30px);
+}
+.example-with-two{
+    font-size:-webkit-calc(10vw + 10px);
+    font-size:calc(10vw + 10px);
+    line-height:-webkit-calc(20vw + 20px);
+    line-height:calc(20vw + 20px);
+}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,4 +32,11 @@ describe('autoprefixer-tv', () => {
 
         return run(input, output);
     });
+
+    it('processes correctly with multiple prefixed rules', () => {
+        const input = readFile('./tests/fixtures/multiple-prefixed-properties.css');
+        const output = readFile('./tests/expects/multiple-prefixed-properties.css');
+
+        return run(input, output);
+    });
 });


### PR DESCRIPTION
This PR closes #1.

The `rule.removeChild` statement mutates the received `rule` variable. Therefore, when trying to add and remove children based on some `index`, we are not accessing the correct values.

This PR fixes this by removing all the target declarations at the end of processing.